### PR TITLE
Add night vision feature

### DIFF
--- a/src/main/java/de/daniel/bactromod/config/ConfigData.java
+++ b/src/main/java/de/daniel/bactromod/config/ConfigData.java
@@ -15,6 +15,9 @@ public class ConfigData {
     public int gammaMultiplier = 15;
 
     @BooleanOption()
+    public boolean nightVision = false;
+
+    @BooleanOption()
     public boolean pumpkinBlur = false;
 
     @IntegerOption(intMin = -100, intMax = 100)

--- a/src/main/java/de/daniel/bactromod/mixins/features/nightvision/GameRendererMixin.java
+++ b/src/main/java/de/daniel/bactromod/mixins/features/nightvision/GameRendererMixin.java
@@ -1,0 +1,16 @@
+package de.daniel.bactromod.mixins.features.nightvision;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import de.daniel.bactromod.config.Config;
+import net.minecraft.client.render.GameRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = GameRenderer.class)
+public class GameRendererMixin {
+    @ModifyReturnValue(method = "getNightVisionStrength", at = @At("RETURN"))
+    private static float cleanerNightVision(float original) {
+        if (!Config.load().nightVision) return 0F;
+        return original;
+    }
+}

--- a/src/main/resources/assets/bactromod/lang/en_us.json
+++ b/src/main/resources/assets/bactromod/lang/en_us.json
@@ -4,6 +4,9 @@
   "bactromod.options.gammaMultiplier": "Brightness boost",
   "bactromod.options.gammaMultiplier.desc": "Boosts in-game brightness by set factor.",
 
+  "bactromod.options.nightVision": "Night vision",
+  "bactromod.options.nightVision.desc": "Disables the night vision status effect.",
+
   "bactromod.options.pumpkinBlur": "Pumpkin blur",
   "bactromod.options.pumpkinBlur.desc": "Disables black texture overlay that strongly limits view when player wears a carved pumpkin.",
 

--- a/src/main/resources/bactromod.mixins.json
+++ b/src/main/resources/bactromod.mixins.json
@@ -8,6 +8,7 @@
     "features.fullbright.MixinLightmapTextureManager",
     "features.lowfire.MixinInGameOverlayRenderer",
     "features.lowshield.MixinHeldItemRenderer",
+    "features.nightvision.GameRendererMixin",
     "features.noopgmswitcher.MixinGameModeSwitcherScreen",
     "features.noopgmswitcher.MixinKeyboard",
     "features.nopumpkinblur.MixinInGameHud",


### PR DESCRIPTION
Some servers have permanent night vision which interferes with fullbright in 1.21.9 and above.
In both pictures I have infinite night vision, first image is ConfigData.nightVision = true, other is false:
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/e5b2e739-e654-4268-9aa8-bfabece1afe5" /> <img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/93752ee4-ddbc-43d7-a944-0a45b3726688" /> 